### PR TITLE
Added test for escaping strings in strings

### DIFF
--- a/src/sos.cc
+++ b/src/sos.cc
@@ -198,3 +198,16 @@ std::string sos::escapeDoubleQuotes(const std::string &input)
 
     return target;
 }
+
+std::string sos::escapeBackslashes(const std::string &input)
+{
+    size_t pos = 0;
+    std::string target(input);
+
+    while ((pos = target.find("\\", pos)) != std::string::npos) {
+        target.replace(pos, 1, "\\\\");
+        pos += 2;
+    }
+
+    return target;
+}

--- a/src/sos.h
+++ b/src/sos.h
@@ -160,6 +160,13 @@ namespace sos {
     };
 
     /**
+     *  \brief  Escape every backslash in input string.
+     *  \param  input   A string to escape its backslashes.
+     *  \return A new string with backslashes escaped.
+     */
+    std::string escapeBackslashes(const std::string& input);
+
+    /**
      *  \brief  Escape every double quote in input string.
      *  \param  input   A string to escape its double quotes.
      *  \return A new string with double quotes escaped.

--- a/src/sosJSON.h
+++ b/src/sosJSON.h
@@ -29,7 +29,8 @@ namespace sos {
 
         virtual void string(const std::string& value, std::ostream& os) {
 
-            std::string normalized = escapeDoubleQuotes(value);
+            std::string normalized = escapeBackslashes(value);
+            normalized = escapeDoubleQuotes(normalized);
             normalized = escapeNewlines(normalized);
 
             os << "\"" << normalized << "\"";

--- a/src/sosYAML.h
+++ b/src/sosYAML.h
@@ -29,7 +29,8 @@ namespace sos {
 
         virtual void string(const std::string& value, std::ostream& os) {
 
-            std::string normalized = escapeDoubleQuotes(value);
+            std::string normalized = escapeBackslashes(value);
+            normalized = escapeDoubleQuotes(normalized);
             normalized = escapeNewlines(normalized);
 
             os << " " << "\"" << normalized << "\"";

--- a/test/test-libsos.cc
+++ b/test/test-libsos.cc
@@ -77,7 +77,8 @@ TEST_CASE("Serailize JSON", "[sos][json]")
     "        }\n"\
     "      ]\n"\
     "    }\n"\
-    "  }\n"\
+    "  },\n"\
+    "  \"json\": \"{\\n    \\\"text\\\": \\\"foo \\\\\\\"bar\\\\\\\" baz\\\\n\\\"\\n}\\n\"\n"\
     "}";
 
     sos::SerializeJSON serializer;
@@ -115,7 +116,8 @@ TEST_CASE("Serialize YAML", "[sos][yaml]")
     "        members: 20\n"\
     "      -\n"\
     "        id: \"flatiron\"\n"\
-    "        members: 10";
+    "        members: 10\n"\
+    "json: \"{\\n    \\\"text\\\": \\\"foo \\\\\\\"bar\\\\\\\" baz\\\\n\\\"\\n}\\n\"";
 
     sos::SerializeYAML serializer;
     sos::Object root;

--- a/test/test.h
+++ b/test/test.h
@@ -46,6 +46,8 @@ void build(sos::Object& root) {
     github.set("orgs", orgs);
     social.set("github", github);
     root.set("contact", social);
+
+    root.set("json", sos::String("{\n    \"text\": \"foo \\\"bar\\\" baz\\n\"\n}\n"));
 }
 
 #endif


### PR DESCRIPTION
As an example, a JSON string containing a string with quotes and newline characters that needs to be escaped, inside the already escaped string.

Notice: This currently fails!
