### PR TITLE
Allow overriding of keys in object

### DIFF
--- a/src/sos.cc
+++ b/src/sos.cc
@@ -121,10 +121,18 @@ sos::Object::Object()
 : Base(ObjectType)
 {}
 
-void sos::Object::set(const std::string& key, const sos::Base& value)
+void sos::Object::set(const std::string& key, const sos::Base& value, bool doNotOverride)
 {
-    if (std::find(keys.begin(), keys.end(), key) != keys.end())
-        throw "key already present in the object";
+    sos::Keys::iterator it = std::find(keys.begin(), keys.end(), key);
+
+    if (it != keys.end()) {
+        if (doNotOverride) {
+            throw "key already present in the object";
+        }
+        else {
+            keys.erase(it);
+        }
+    }
 
     keys.push_back(key);
     object().operator[](key) = value;

--- a/src/sos.h
+++ b/src/sos.h
@@ -131,7 +131,7 @@ namespace sos {
         /** Constructor */
         Object();
 
-        void set(const std::string& key, const Base& value);
+        void set(const std::string& key, const Base& value, bool doNotOverride = false);
 
         /** Check if empty */
         bool empty();

--- a/test/test-libsos.cc
+++ b/test/test-libsos.cc
@@ -43,6 +43,17 @@ TEST_CASE("Array when not empty", "[sos]")
     REQUIRE(!root.empty());
 }
 
+TEST_CASE("Override key in object by default", "[sos]")
+{
+	sos::Object root;
+	root.set("user", sos::String("pksunkara"));
+	root.set("user", sos::String("pavan"));
+
+	REQUIRE(root.keys.size() == 1);
+	REQUIRE(root.keys.at(0) == "user");
+	REQUIRE(root.object().operator[]("user").str == "pavan");
+}
+
 TEST_CASE("Serailize JSON", "[sos][json]")
 {
     std::stringstream output;


### PR DESCRIPTION
Currently, by default we don't allow overriding of keys in an object but this PR changes that while adding an option to still retain the previous behaviour.
