### PR TITLE
Don't serialise numbers with scientific notation in JSON

### DIFF
--- a/src/sos.cc
+++ b/src/sos.cc
@@ -189,7 +189,7 @@ void sos::Serialize::process(const Base& root, std::ostream& os, size_t level)
         case Base::ObjectType:
             object(root, os, level);
             break;
-            
+
         default:
             break;
     }

--- a/src/sosJSON.h
+++ b/src/sosJSON.h
@@ -36,9 +36,23 @@ namespace sos {
             os << "\"" << normalized << "\"";
         }
 
+        /// Prints the given double to the output stream
+        /// Note: Does not print scientific notation
         virtual void number(double value, std::ostream& os) {
 
-            os << value;
+            std::stringstream output;
+            output << std::fixed << value;
+            std::string stringValue = output.str();
+
+            // "std:fixed" output always shows the decimal place and any
+            // leading zero's. Let's trim those out if there are any:
+            size_t position = stringValue.find_last_not_of("0");
+            if (stringValue.at(position) == '.') {
+                --position;
+            }
+            stringValue.resize(position + 1);
+
+            os << stringValue;
         }
 
         virtual void boolean(bool value, std::ostream& os) {

--- a/test/test-libsos.cc
+++ b/test/test-libsos.cc
@@ -116,6 +116,23 @@ TEST_CASE("Serailize JSON", "[sos][json]")
     REQUIRE(output.str() == expected);
 }
 
+TEST_CASE("Serializing JSON numbers use fixed notation", "[sos][json]")
+{
+    std::stringstream output;
+    std::string expected = \
+    "{\n"\
+    "  \"number\": 1234567890\n"\
+    "}";
+
+    sos::Object root;
+    sos::SerializeJSON serializer;
+    root.set("number", sos::Number(1234567890));
+
+    serializer.process(root, output);
+
+    REQUIRE(output.str() == expected);
+}
+
 TEST_CASE("Serialize YAML", "[sos][yaml]")
 {
     std::stringstream output;


### PR DESCRIPTION
This is to fix https://github.com/apiaryio/drafter/issues/140, also to note, scientific notation is allowed in JSON so we don't necessarily need to change the output.

This was unfortunately far tricker than I imaged, both the `<<` operator to a stream cannot print a number without trailing precision and scientific notation. There is also no format operator for `snpritnf` to serialise a double to a string as we would like.

After digging around, I think the easiest solution to the problem would be to use the `std::fixed` option with a stream and then strip the trailing precision.

I'm very welcome to alternative solutions if anyone has any ideas. I've added sufficient comments to the code since this is non-obvious.
