### PR TITLE
Add missing include for sstream in JSON

### DIFF
--- a/src/sosJSON.h
+++ b/src/sosJSON.h
@@ -9,6 +9,7 @@
 #ifndef SOS_JSON_H
 #define SOS_JSON_H
 
+#include <sstream>
 #include "sos.h"
 
 namespace sos {


### PR DESCRIPTION
The testing framework appears to implicitly include this and was causing
the tests to pass without this missing include.
